### PR TITLE
Switching from VMC identifiers to ga4gh

### DIFF
--- a/refget/hash_functions.py
+++ b/refget/hash_functions.py
@@ -7,31 +7,31 @@ import hashlib
 import binascii
 
 def trunc512_digest(seq, offset=24):
-    digest = hashlib.sha512(seq.encode()).digest()
+    digest = hashlib.sha512(seq.encode('utf-8')).digest()
     hex_digest = binascii.hexlify(digest[:offset])
-    return hex_digest.decode()
+    return hex_digest.decode("utf-8") 
 
-def vmc_digest(seq, digest_size=24):
+def ga4gh_digest(seq, digest_size=24):
     # b64 encoding results in 4/3 size expansion of data and padded if
     # not multiple of 3, which doesn't make sense for this use
     assert digest_size % 3 == 0, "digest size must be multiple of 3"
-    digest = hashlib.sha512(seq).digest()
-    return _vmc_format(digest, digest_size)
+    digest = hashlib.sha512(seq.encode('utf-8')).digest()
+    return _ga4gh_format(digest, digest_size)
 
-def _vmc_format(digest, digest_size=24):
+def _ga4gh_format(digest, digest_size=24):
     tdigest_b64us = base64.urlsafe_b64encode(digest[:digest_size])
-    return "VMC:GS_{}".format(tdigest_b64us)
+    return "ga4gh:SQ.{}".format(tdigest_b64us.decode("utf-8"))
 
-def vmc_to_trunc512(vmc):
-    base64_strip = vmc.replace("VMC:GS_","")
+def ga4gh_to_trunc512(vmc):
+    base64_strip = vmc.replace("ga4gh:SQ.","")
     digest = base64.urlsafe_b64decode(base64_strip)
     hex_digest = binascii.hexlify(digest)
-    return hex_digest
+    return hex_digest.decode("utf-8") 
 
-def trunc512_to_vmc(trunc512):
+def trunc512_to_ga4gh(trunc512):
     digest_length = len(trunc512)*2
     digest = binascii.unhexlify(trunc512)
-    return _vmc_format(digest, digest_length)
+    return _ga4gh_format(digest, digest_length)
 
 def md5(seq):
     return hashlib.md5(seq.encode()).hexdigest()


### PR DESCRIPTION
During refget's inception and now, VRS now defines a sequence identifier format of ga4gh:SQ---, where --- is a base64 url encoded representation of the SHA-512 sequence 24bits digest. TRUNC512 and ga4gh are compatible with each other.